### PR TITLE
Content pack decoupling

### DIFF
--- a/HenryMod/HenryAPI.csproj
+++ b/HenryMod/HenryAPI.csproj
@@ -37,8 +37,8 @@
 		<PackageReference Include="R2API.DamageType" Version="1.*" />
 		<PackageReference Include="R2API.Dot" Version="1.*" />
 	</ItemGroup>
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <!-- <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="REM follow the Building Your Mod page on the henrytutorial wiki for more information on this&#xD;&#xA;REM change this to your username (or add yours if you're working in a team or somethin)&#xD;&#xA;if &quot;$(Username)&quot; == &quot;Erikbir&quot; set build=true&#xD;&#xA;&#xD;&#xA;if defined build (&#xD;&#xA;&#xD;&#xA;REM copy the built mod to our Build folder&#xD;&#xA;copy &quot;$(TargetPath)&quot; &quot;$(ProjectDir)..\Build\plugins&quot;&#xD;&#xA;&#xD;&#xA;REM copy the assetbundle from our unity project to our Build folder&#xD;&#xA;REM change these paths to your (now hopefully renamed) folders&#xD;&#xA;if exist &quot;$(ProjectDir)..\HenryUnityProject\AssetBundles\myassetbundle&quot; (&#xD;&#xA;copy &quot;$(ProjectDir)..\HenryUnityProject\AssetBundles\myassetbundle&quot; &quot;$(ProjectDir)..\Build\plugins\AssetBundles&quot;&#xD;&#xA;)&#xD;&#xA;&#xD;&#xA;REM copy the whole Build\plugins folder into your r2modman profile. This mimics how r2modman will install your mod&#xD;&#xA;Xcopy /E /I /Y &quot;$(ProjectDir)..\Build\plugins&quot; &quot;E:\r2Profiles\Blinx Returns\BepInEx\plugins\rob-henrymod\&quot;&#xD;&#xA;)&#xD;&#xA;" />
-  </Target>
+  </Target> -->
 
 </Project>

--- a/HenryMod/HenryAPI.csproj
+++ b/HenryMod/HenryAPI.csproj
@@ -19,23 +19,20 @@
   </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BepInEx.Analyzers" Version="1.0.*">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="BepInEx.Core" Version="5.*" />
-		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.1.275-r.0" />
-		<PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
-		<PackageReference Include="MMHOOK.RoR2" Version="2024.8.28">
-			<NoWarn>NU1701</NoWarn>
-		</PackageReference>
-		<PackageReference Include="R2API.Core" Version="5.*" />
-		<PackageReference Include="R2API.Prefab" Version="1.*" />
-		<PackageReference Include="R2API.RecalculateStats" Version="1.*" />
-		<PackageReference Include="R2API.Language" Version="1.*" />
-		<PackageReference Include="R2API.Sound" Version="1.*" />
-		<PackageReference Include="R2API.DamageType" Version="1.*" />
-		<PackageReference Include="R2API.Dot" Version="1.*" />
+	<PackageReference Include="BepInEx.Analyzers" Version="1.0.*">
+		<PrivateAssets>all</PrivateAssets>
+		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	</PackageReference>
+
+	<PackageReference Include="BepInEx.Core" Version="5.*" />
+	<PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.9-r.0" />
+	<PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
+	<PackageReference Include="MMHOOK.RoR2" Version="2025.6.3" />
+	<PackageReference Include="R2API.Core" Version="5.*" />
+	<PackageReference Include="R2API.Prefab" Version="1.*" />
+	<PackageReference Include="R2API.RecalculateStats" Version="1.*" />
+	<PackageReference Include="R2API.Language" Version="1.*" />
+	<PackageReference Include="R2API.Sound" Version="1.*" />
 	</ItemGroup>
   <!-- <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="REM follow the Building Your Mod page on the henrytutorial wiki for more information on this&#xD;&#xA;REM change this to your username (or add yours if you're working in a team or somethin)&#xD;&#xA;if &quot;$(Username)&quot; == &quot;Erikbir&quot; set build=true&#xD;&#xA;&#xD;&#xA;if defined build (&#xD;&#xA;&#xD;&#xA;REM copy the built mod to our Build folder&#xD;&#xA;copy &quot;$(TargetPath)&quot; &quot;$(ProjectDir)..\Build\plugins&quot;&#xD;&#xA;&#xD;&#xA;REM copy the assetbundle from our unity project to our Build folder&#xD;&#xA;REM change these paths to your (now hopefully renamed) folders&#xD;&#xA;if exist &quot;$(ProjectDir)..\HenryUnityProject\AssetBundles\myassetbundle&quot; (&#xD;&#xA;copy &quot;$(ProjectDir)..\HenryUnityProject\AssetBundles\myassetbundle&quot; &quot;$(ProjectDir)..\Build\plugins\AssetBundles&quot;&#xD;&#xA;)&#xD;&#xA;&#xD;&#xA;REM copy the whole Build\plugins folder into your r2modman profile. This mimics how r2modman will install your mod&#xD;&#xA;Xcopy /E /I /Y &quot;$(ProjectDir)..\Build\plugins&quot; &quot;E:\r2Profiles\Blinx Returns\BepInEx\plugins\rob-henrymod\&quot;&#xD;&#xA;)&#xD;&#xA;" />

--- a/HenryMod/HenryAPI.sln
+++ b/HenryMod/HenryAPI.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.33920.266
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HenryMod", "HenryMod.csproj", "{685EAC6F-14E3-4439-9394-3345F1CBD1AD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HenryAPI", "HenryAPI.csproj", "{685EAC6F-14E3-4439-9394-3345F1CBD1AD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/HenryMod/HenryAPIPlugin.cs
+++ b/HenryMod/HenryAPIPlugin.cs
@@ -15,19 +15,19 @@ namespace HenryAPI
     //[BepInDependency("com.rune580.riskofoptions", BepInDependency.DependencyFlags.SoftDependency)]
     [NetworkCompatibility(CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.EveryoneNeedSameModVersion)]
     [BepInPlugin(MODUID, MODNAME, MODVERSION)]
-    public class HenryPlugin : BaseUnityPlugin
+    public class HenryAPIPlugin : BaseUnityPlugin
     {
         // if you do not change this, you are giving permission to deprecate the mod-
         //  please change the names to your own stuff, thanks
         //   this shouldn't even have to be said
-        public const string MODUID = "com.rob.HenryMod";
-        public const string MODNAME = "HenryMod";
+        public const string MODUID = "com.buns.HenryAPI";
+        public const string MODNAME = "HenryAPI";
         public const string MODVERSION = "1.0.0";
 
         // a prefix for name tokens to prevent conflicts- please capitalize all name tokens for convention
-        public const string DEVELOPER_PREFIX = "ROB";
+        public const string DEVELOPER_PREFIX = "BUNS";
 
-        public static HenryPlugin instance;
+        public static HenryAPIPlugin instance;
 
         void Awake()
         {
@@ -38,9 +38,6 @@ namespace HenryAPI
 
             // used when you want to properly set up language folders
             Modules.Language.Init();
-
-            // make a content pack and add it. this has to be last
-            new Modules.ContentPacks().Initialize();
         }
     }
 }

--- a/HenryMod/HenryAPIPlugin.cs
+++ b/HenryMod/HenryAPIPlugin.cs
@@ -1,5 +1,4 @@
 ﻿using BepInEx;
-using HenryMod.Survivors.Henry;
 using R2API.Utils;
 using RoR2;
 using System.Collections.Generic;

--- a/HenryMod/HenryAPIPlugin.cs
+++ b/HenryMod/HenryAPIPlugin.cs
@@ -8,8 +8,6 @@ using System.Security.Permissions;
 
 [module: UnverifiableCode]
 [assembly: SecurityPermission(SecurityAction.RequestMinimum, SkipVerification = true)]
-
-//rename this namespace
 namespace HenryAPI
 {
     //[BepInDependency("com.rune580.riskofoptions", BepInDependency.DependencyFlags.SoftDependency)]
@@ -17,14 +15,9 @@ namespace HenryAPI
     [BepInPlugin(MODUID, MODNAME, MODVERSION)]
     public class HenryAPIPlugin : BaseUnityPlugin
     {
-        // if you do not change this, you are giving permission to deprecate the mod-
-        //  please change the names to your own stuff, thanks
-        //   this shouldn't even have to be said
         public const string MODUID = "com.buns.HenryAPI";
         public const string MODNAME = "HenryAPI";
         public const string MODVERSION = "1.0.0";
-
-        // a prefix for name tokens to prevent conflicts- please capitalize all name tokens for convention
         public const string DEVELOPER_PREFIX = "BUNS";
 
         public static HenryAPIPlugin instance;

--- a/HenryMod/HenryPlugin.cs
+++ b/HenryMod/HenryPlugin.cs
@@ -10,7 +10,7 @@ using System.Security.Permissions;
 [assembly: SecurityPermission(SecurityAction.RequestMinimum, SkipVerification = true)]
 
 //rename this namespace
-namespace HenryMod
+namespace HenryAPI
 {
     //[BepInDependency("com.rune580.riskofoptions", BepInDependency.DependencyFlags.SoftDependency)]
     [NetworkCompatibility(CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.EveryoneNeedSameModVersion)]

--- a/HenryMod/Log.cs
+++ b/HenryMod/Log.cs
@@ -2,7 +2,7 @@
 using System.Security;
 using System.Security.Permissions;
 
-namespace HenryMod
+namespace HenryAPI
 {
     internal static class Log
     {

--- a/HenryMod/Modules/Asset.cs
+++ b/HenryMod/Modules/Asset.cs
@@ -93,20 +93,6 @@ namespace HenryAPI.Modules
             }
         }
 
-        [Obsolete("just load from addressables")]
-        internal static GameObject LoadCrosshair(string crosshairName)
-        {
-            GameObject loadedCrosshair = RoR2.LegacyResourcesAPI.Load<GameObject>("Prefabs/Crosshair/" + crosshairName + "Crosshair");
-            if (loadedCrosshair == null)
-            {
-                Log.Error($"could not load crosshair with the name {crosshairName}. defaulting to Standard");
-
-                return RoR2.LegacyResourcesAPI.Load<GameObject>("Prefabs/Crosshair/StandardCrosshair");
-            }
-
-            return loadedCrosshair;
-        }
-
         internal static GameObject LoadEffect(this AssetBundle assetBundle, string resourceName, bool parentToTransform) => LoadEffect(assetBundle, resourceName, "", parentToTransform);
         internal static GameObject LoadEffect(this AssetBundle assetBundle, string resourceName, string soundName = "", bool parentToTransform = false)
         {

--- a/HenryMod/Modules/Asset.cs
+++ b/HenryMod/Modules/Asset.cs
@@ -10,7 +10,7 @@ using RoR2.Projectile;
 using Path = System.IO.Path;
 using System;
 
-namespace HenryMod.Modules
+namespace HenryAPI.Modules
 {
     internal static class Asset
     {

--- a/HenryMod/Modules/Asset.cs
+++ b/HenryMod/Modules/Asset.cs
@@ -34,7 +34,7 @@ namespace HenryAPI.Modules
             AssetBundle assetBundle = null;
             try
             {
-                assetBundle = AssetBundle.LoadFromFile(Path.Combine(Path.GetDirectoryName(HenryPlugin.instance.Info.Location), "AssetBundles", bundleName));
+                assetBundle = AssetBundle.LoadFromFile(Path.Combine(Path.GetDirectoryName(HenryAPIPlugin.instance.Info.Location), "AssetBundles", bundleName));
             }
             catch (System.Exception e)
             {
@@ -47,7 +47,7 @@ namespace HenryAPI.Modules
 
         }
 
-        internal static GameObject CloneTracer(string originalTracerName, string newTracerName)
+        internal static GameObject CloneTracer(ContentPackContainer contentPack, string originalTracerName, string newTracerName)
         {
             if (RoR2.LegacyResourcesAPI.Load<GameObject>("Prefabs/Effects/Tracers/" + originalTracerName) == null) 
                 return null;
@@ -61,7 +61,7 @@ namespace HenryAPI.Modules
             newTracer.GetComponent<Tracer>().speed = 250f;
             newTracer.GetComponent<Tracer>().length = 50f;
 
-            Modules.Content.CreateAndAddEffectDef(newTracer);
+            Modules.Content.CreateAndAddEffectDef(contentPack, newTracer);
 
             return newTracer;
         }
@@ -93,8 +93,8 @@ namespace HenryAPI.Modules
             }
         }
 
-        internal static GameObject LoadEffect(this AssetBundle assetBundle, string resourceName, bool parentToTransform) => LoadEffect(assetBundle, resourceName, "", parentToTransform);
-        internal static GameObject LoadEffect(this AssetBundle assetBundle, string resourceName, string soundName = "", bool parentToTransform = false)
+        internal static GameObject LoadEffect(this AssetBundle assetBundle, ContentPackContainer contentPack, string resourceName, bool parentToTransform) => LoadEffect(assetBundle, contentPack, resourceName, "", parentToTransform);
+        internal static GameObject LoadEffect(this AssetBundle assetBundle, ContentPackContainer contentPack, string resourceName, string soundName = "", bool parentToTransform = false)
         {
             GameObject newEffect = assetBundle.LoadAsset<GameObject>(resourceName);
 
@@ -114,7 +114,7 @@ namespace HenryAPI.Modules
             effect.positionAtReferencedTransform = true;
             effect.soundName = soundName;
 
-            Modules.Content.CreateAndAddEffectDef(newEffect);
+            Modules.Content.CreateAndAddEffectDef(contentPack, newEffect);
 
             return newEffect;
         }
@@ -140,7 +140,7 @@ namespace HenryAPI.Modules
             return newPrefab;
         }
 
-        internal static GameObject LoadAndAddProjectilePrefab(this AssetBundle assetBundle, string newPrefabName)
+        internal static GameObject LoadAndAddProjectilePrefab(this AssetBundle assetBundle, ContentPackContainer contentPack, string newPrefabName)
         {
             GameObject newPrefab = assetBundle.LoadAsset<GameObject>(newPrefabName);
             if(newPrefab == null)
@@ -149,7 +149,7 @@ namespace HenryAPI.Modules
                 return null;
             }
 
-            Content.AddProjectilePrefab(newPrefab);
+            Content.AddProjectilePrefab(contentPack, newPrefab);
             return newPrefab;
         }
     }

--- a/HenryMod/Modules/BaseContent/Achievements/BaseMasteryAchievement.cs
+++ b/HenryMod/Modules/BaseContent/Achievements/BaseMasteryAchievement.cs
@@ -1,7 +1,7 @@
 ﻿using RoR2;
 using RoR2.Achievements;
 
-namespace HenryMod.Modules.Achievements
+namespace HenryAPI.Modules.Achievements
 {
     public abstract class BaseMasteryAchievement : BaseAchievement
     {

--- a/HenryMod/Modules/BaseContent/BaseStates/BaseMeleeAttack.cs
+++ b/HenryMod/Modules/BaseContent/BaseStates/BaseMeleeAttack.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Networking;
 
-namespace HenryMod.Modules.BaseStates
+namespace HenryAPI.Modules.BaseStates
 {
     public abstract class BaseMeleeAttack : BaseSkillState, SteppedSkillDef.IStepSetter
     {

--- a/HenryMod/Modules/BaseContent/BaseStates/BaseTimedSkillState.cs
+++ b/HenryMod/Modules/BaseContent/BaseStates/BaseTimedSkillState.cs
@@ -1,7 +1,7 @@
 ﻿using EntityStates;
 using System;
 
-namespace HenryMod.Modules.BaseStates
+namespace HenryAPI.Modules.BaseStates
 {
     //see example skills below
     public abstract class BaseTimedSkillState : BaseSkillState

--- a/HenryMod/Modules/BaseContent/Characters/CharacterBase.cs
+++ b/HenryMod/Modules/BaseContent/Characters/CharacterBase.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace HenryMod.Modules.Characters
+namespace HenryAPI.Modules.Characters
 {
     public abstract class CharacterBase<T> where T : CharacterBase<T>, new()
     {

--- a/HenryMod/Modules/BaseContent/Characters/ItemDisplaysBase.cs
+++ b/HenryMod/Modules/BaseContent/Characters/ItemDisplaysBase.cs
@@ -1,7 +1,7 @@
 ﻿using RoR2;
 using System.Collections.Generic;
 
-namespace HenryMod.Modules.Characters
+namespace HenryAPI.Modules.Characters
 {
     public abstract class ItemDisplaysBase
     {

--- a/HenryMod/Modules/BaseContent/Characters/SurvivorBase.cs
+++ b/HenryMod/Modules/BaseContent/Characters/SurvivorBase.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using RoR2.Skills;
 
-namespace HenryMod.Modules.Characters
+namespace HenryAPI.Modules.Characters
 {
     public abstract class SurvivorBase<T> : CharacterBase<T> where T : SurvivorBase<T>, new()
     {

--- a/HenryMod/Modules/Config.cs
+++ b/HenryMod/Modules/Config.cs
@@ -6,7 +6,7 @@ namespace HenryAPI.Modules
 {
     public static class Config
     {
-        public static ConfigFile MyConfig = HenryPlugin.instance.Config;
+        public static ConfigFile MyConfig = HenryAPIPlugin.instance.Config;
 
         /// <summary>
         /// automatically makes config entries for disabling survivors

--- a/HenryMod/Modules/Config.cs
+++ b/HenryMod/Modules/Config.cs
@@ -2,7 +2,7 @@
 using BepInEx.Configuration;
 using UnityEngine;
 
-namespace HenryMod.Modules
+namespace HenryAPI.Modules
 {
     public static class Config
     {

--- a/HenryMod/Modules/Content.cs
+++ b/HenryMod/Modules/Content.cs
@@ -6,32 +6,31 @@ using UnityEngine;
 namespace HenryAPI.Modules
 {
     //consolidate contentaddition here in case something breaks and/or want to move to r2api
-    internal class Content
+    public static class Content
     {
-        internal static void AddCharacterBodyPrefab(GameObject bprefab)
+        public static void AddCharacterBodyPrefab(ContentPackContainer contentPack, GameObject bprefab)
         {
-            ContentPacks.bodyPrefabs.Add(bprefab);
+            contentPack.bodyPrefabs.Add(bprefab);
         }
 
-        internal static void AddMasterPrefab(GameObject prefab)
+        public static void AddMasterPrefab(ContentPackContainer contentPack, GameObject prefab)
         {
-            ContentPacks.masterPrefabs.Add(prefab);
+            contentPack.masterPrefabs.Add(prefab);
         }
 
-        internal static void AddProjectilePrefab(GameObject prefab)
+        public static void AddProjectilePrefab(ContentPackContainer contentPack, GameObject prefab)
         {
-            ContentPacks.projectilePrefabs.Add(prefab);
+            contentPack.projectilePrefabs.Add(prefab);
         }
 
-        internal static void AddSurvivorDef(SurvivorDef survivorDef)
+        public static void AddSurvivorDef(ContentPackContainer contentPack, SurvivorDef survivorDef)
         {
-
-            ContentPacks.survivorDefs.Add(survivorDef);
+            contentPack.survivorDefs.Add(survivorDef);
         }
-        internal static void CreateSurvivor(GameObject bodyPrefab, GameObject displayPrefab, Color charColor, string tokenPrefix) { CreateSurvivor(bodyPrefab, displayPrefab, charColor, tokenPrefix, null, 100f); }
-        internal static void CreateSurvivor(GameObject bodyPrefab, GameObject displayPrefab, Color charColor, string tokenPrefix, float sortPosition) { CreateSurvivor(bodyPrefab, displayPrefab, charColor, tokenPrefix, null, sortPosition); }
-        internal static void CreateSurvivor(GameObject bodyPrefab, GameObject displayPrefab, Color charColor, string tokenPrefix, UnlockableDef unlockableDef) { CreateSurvivor(bodyPrefab, displayPrefab, charColor, tokenPrefix, unlockableDef, 100f); }
-        internal static void CreateSurvivor(GameObject bodyPrefab, GameObject displayPrefab, Color charColor, string tokenPrefix, UnlockableDef unlockableDef, float sortPosition)
+        public static void CreateSurvivor(ContentPackContainer contentPack, GameObject bodyPrefab, GameObject displayPrefab, Color charColor, string tokenPrefix) { CreateSurvivor(contentPack, bodyPrefab, displayPrefab, charColor, tokenPrefix, null, 100f); }
+        public static void CreateSurvivor(ContentPackContainer contentPack, GameObject bodyPrefab, GameObject displayPrefab, Color charColor, string tokenPrefix, float sortPosition) { CreateSurvivor(contentPack, bodyPrefab, displayPrefab, charColor, tokenPrefix, null, sortPosition); }
+        public static void CreateSurvivor(ContentPackContainer contentPack, GameObject bodyPrefab, GameObject displayPrefab, Color charColor, string tokenPrefix, UnlockableDef unlockableDef) { CreateSurvivor(contentPack, bodyPrefab, displayPrefab, charColor, tokenPrefix, unlockableDef, 100f); }
+        public static void CreateSurvivor(ContentPackContainer contentPack, GameObject bodyPrefab, GameObject displayPrefab, Color charColor, string tokenPrefix, UnlockableDef unlockableDef, float sortPosition)
         {
             SurvivorDef survivorDef = ScriptableObject.CreateInstance<SurvivorDef>();
             survivorDef.bodyPrefab = bodyPrefab;
@@ -47,45 +46,45 @@ namespace HenryAPI.Modules
             survivorDef.desiredSortPosition = sortPosition;
             survivorDef.unlockableDef = unlockableDef;
 
-            Modules.Content.AddSurvivorDef(survivorDef);
+            Modules.Content.AddSurvivorDef(contentPack, survivorDef);
         }
 
-        internal static void AddUnlockableDef(UnlockableDef unlockableDef)
+        public static void AddUnlockableDef(ContentPackContainer contentPack, UnlockableDef unlockableDef)
         {
-            ContentPacks.unlockableDefs.Add(unlockableDef);
+            contentPack.unlockableDefs.Add(unlockableDef);
         }
-        internal static UnlockableDef CreateAndAddUnlockbleDef(string identifier, string nameToken, Sprite achievementIcon)
+        public static UnlockableDef CreateAndAddUnlockbleDef(ContentPackContainer contentPack, string identifier, string nameToken, Sprite achievementIcon)
         {
             UnlockableDef unlockableDef = ScriptableObject.CreateInstance<UnlockableDef>();
             unlockableDef.cachedName = identifier;
             unlockableDef.nameToken = nameToken;
             unlockableDef.achievementIcon = achievementIcon;
 
-            AddUnlockableDef(unlockableDef);
+            AddUnlockableDef(contentPack, unlockableDef);
 
             return unlockableDef;
         }
 
-        internal static void AddSkillDef(SkillDef skillDef)
+        public static void AddSkillDef(ContentPackContainer contentPack, SkillDef skillDef)
         {
-            ContentPacks.skillDefs.Add(skillDef);
+            contentPack.skillDefs.Add(skillDef);
         }
 
-        internal static void AddSkillFamily(SkillFamily skillFamily)
+        public static void AddSkillFamily(ContentPackContainer contentPack, SkillFamily skillFamily)
         {
-            ContentPacks.skillFamilies.Add(skillFamily);
+            contentPack.skillFamilies.Add(skillFamily);
         }
 
-        internal static void AddEntityState(Type entityState)
+        public static void AddEntityState(ContentPackContainer contentPack, Type entityState)
         {
-            ContentPacks.entityStates.Add(entityState);
+            contentPack.entityStates.Add(entityState);
         }
 
-        internal static void AddBuffDef(BuffDef buffDef)
+        public static void AddBuffDef(ContentPackContainer contentPack, BuffDef buffDef)
         {
-            ContentPacks.buffDefs.Add(buffDef);
+            contentPack.buffDefs.Add(buffDef);
         }
-        internal static BuffDef CreateAndAddBuff(string buffName, Sprite buffIcon, Color buffColor, bool canStack, bool isDebuff)
+        public static BuffDef CreateAndAddBuff(ContentPackContainer contentPack, string buffName, Sprite buffIcon, Color buffColor, bool canStack, bool isDebuff)
         {
             BuffDef buffDef = ScriptableObject.CreateInstance<BuffDef>();
             buffDef.name = buffName;
@@ -95,35 +94,35 @@ namespace HenryAPI.Modules
             buffDef.eliteDef = null;
             buffDef.iconSprite = buffIcon;
 
-            AddBuffDef(buffDef);
+            AddBuffDef(contentPack, buffDef);
 
             return buffDef;
         }
 
-        internal static void AddEffectDef(EffectDef effectDef)
+        public static void AddEffectDef(ContentPackContainer contentPack, EffectDef effectDef)
         {
-            ContentPacks.effectDefs.Add(effectDef);
+            contentPack.effectDefs.Add(effectDef);
         }
-        internal static EffectDef CreateAndAddEffectDef(GameObject effectPrefab)
+        public static EffectDef CreateAndAddEffectDef(ContentPackContainer contentPack, GameObject effectPrefab)
         {
             EffectDef effectDef = new EffectDef(effectPrefab);
 
-            AddEffectDef(effectDef);
+            AddEffectDef(contentPack, effectDef);
 
             return effectDef;
         }
 
-        internal static void AddNetworkSoundEventDef(NetworkSoundEventDef networkSoundEventDef)
+        public static void AddNetworkSoundEventDef(ContentPackContainer contentPack, NetworkSoundEventDef networkSoundEventDef)
         {
-            ContentPacks.networkSoundEventDefs.Add(networkSoundEventDef);
+            contentPack.networkSoundEventDefs.Add(networkSoundEventDef);
         }
-        internal static NetworkSoundEventDef CreateAndAddNetworkSoundEventDef(string eventName)
+        public static NetworkSoundEventDef CreateAndAddNetworkSoundEventDef(ContentPackContainer contentPack, string eventName)
         {
             NetworkSoundEventDef networkSoundEventDef = ScriptableObject.CreateInstance<NetworkSoundEventDef>();
             networkSoundEventDef.akId = AkSoundEngine.GetIDFromString(eventName);
             networkSoundEventDef.eventName = eventName;
 
-            AddNetworkSoundEventDef(networkSoundEventDef);
+            AddNetworkSoundEventDef(contentPack, networkSoundEventDef);
             
             return networkSoundEventDef;
         }

--- a/HenryMod/Modules/Content.cs
+++ b/HenryMod/Modules/Content.cs
@@ -3,7 +3,7 @@ using RoR2.Skills;
 using System;
 using UnityEngine;
 
-namespace HenryMod.Modules
+namespace HenryAPI.Modules
 {
     //consolidate contentaddition here in case something breaks and/or want to move to r2api
     internal class Content

--- a/HenryMod/Modules/ContentPackContainer.cs
+++ b/HenryMod/Modules/ContentPackContainer.cs
@@ -6,26 +6,26 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace HenryAPI.Modules {
-    internal class ContentPacks : IContentPackProvider
+    public class ContentPackContainer : IContentPackProvider
     {
         internal ContentPack contentPack = new ContentPack();
-        public string identifier => HenryPlugin.MODUID;
+        public string identifier => HenryAPIPlugin.MODUID;
 
-        public static List<GameObject> bodyPrefabs = new List<GameObject>();
-        public static List<GameObject> masterPrefabs = new List<GameObject>();
-        public static List<GameObject> projectilePrefabs = new List<GameObject>();
+        public List<GameObject> bodyPrefabs = new List<GameObject>();
+        public List<GameObject> masterPrefabs = new List<GameObject>();
+        public List<GameObject> projectilePrefabs = new List<GameObject>();
 
-        public static List<SurvivorDef> survivorDefs = new List<SurvivorDef>();
-        public static List<UnlockableDef> unlockableDefs = new List<UnlockableDef>();
+        public  List<SurvivorDef> survivorDefs = new List<SurvivorDef>();
+        public  List<UnlockableDef> unlockableDefs = new List<UnlockableDef>();
 
-        public static List<SkillFamily> skillFamilies = new List<SkillFamily>();
-        public static List<SkillDef> skillDefs = new List<SkillDef>();
-        public static List<Type> entityStates = new List<Type>();
+        public List<SkillFamily> skillFamilies = new List<SkillFamily>();
+        public List<SkillDef> skillDefs = new List<SkillDef>();
+        public List<Type> entityStates = new List<Type>();
 
-        public static List<BuffDef> buffDefs = new List<BuffDef>();
-        public static List<EffectDef> effectDefs = new List<EffectDef>();
+        public List<BuffDef> buffDefs = new List<BuffDef>();
+        public List<EffectDef> effectDefs = new List<EffectDef>();
 
-        public static List<NetworkSoundEventDef> networkSoundEventDefs = new List<NetworkSoundEventDef>();
+        public List<NetworkSoundEventDef> networkSoundEventDefs = new List<NetworkSoundEventDef>();
 
         public void Initialize()
         {

--- a/HenryMod/Modules/ContentPacks.cs
+++ b/HenryMod/Modules/ContentPacks.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace HenryMod.Modules {
+namespace HenryAPI.Modules {
     internal class ContentPacks : IContentPackProvider
     {
         internal ContentPack contentPack = new ContentPack();

--- a/HenryMod/Modules/ItemDisplayCheck.cs
+++ b/HenryMod/Modules/ItemDisplayCheck.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-namespace HenryMod.Modules
+namespace HenryAPI.Modules
 {
     internal static class ItemDisplayCheck
     {

--- a/HenryMod/Modules/ItemDisplays.cs
+++ b/HenryMod/Modules/ItemDisplays.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace HenryMod.Modules
+namespace HenryAPI.Modules
 {
     internal static class ItemDisplays
     {

--- a/HenryMod/Modules/Language.cs
+++ b/HenryMod/Modules/Language.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace HenryMod.Modules {
+namespace HenryAPI.Modules {
     internal static class Language
     {
         public static string TokensOutput = "";

--- a/HenryMod/Modules/Materials.cs
+++ b/HenryMod/Modules/Materials.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 
-namespace HenryMod.Modules
+namespace HenryAPI.Modules
 {
     internal static class Materials
     {

--- a/HenryMod/Modules/Prefabs.cs
+++ b/HenryMod/Modules/Prefabs.cs
@@ -2,7 +2,7 @@
 using RoR2;
 using System.Collections.Generic;
 using UnityEngine;
-using HenryMod.Modules.Characters;
+using HenryAPI.Modules.Characters;
 using RoR2.CharacterAI;
 using static RoR2.CharacterAI.AISkillDriver;
 using RoR2.Skills;
@@ -86,35 +86,35 @@ namespace HenryAPI.Modules
         /// <summary>
         /// clone a body according to your BodyInfo, load your model prefab from the assetbundle, and set up components on both objects through code
         /// </summary>
-        public static GameObject CreateBodyPrefab(AssetBundle assetBundle, string modelPrefabName, BodyInfo bodyInfo)
+        public static GameObject CreateBodyPrefab(ContentPackContainer contentPack, AssetBundle assetBundle, string modelPrefabName, BodyInfo bodyInfo)
         {
-            return CreateBodyPrefab(LoadCharacterModel(assetBundle, modelPrefabName), bodyInfo);
+            return CreateBodyPrefab(contentPack, LoadCharacterModel(assetBundle, modelPrefabName), bodyInfo);
         }
         /// <summary>
         /// clone a body according to your BodyInfo, pass in your model prefab, and set up components on both objects through code
         /// </summary>
-        public static GameObject CreateBodyPrefab(GameObject model, BodyInfo bodyInfo)
+        public static GameObject CreateBodyPrefab(ContentPackContainer contentPack, GameObject model, BodyInfo bodyInfo)
         {
-            return CreateBodyPrefab(CloneCharacterBody(bodyInfo), model, bodyInfo);
+            return CreateBodyPrefab(contentPack, CloneCharacterBody(bodyInfo), model, bodyInfo);
         }
         /// <summary>
         /// Pass in a body prefab, loads your model from the assetbundle, and set up components on both objects through code
         /// </summary>
-        public static GameObject CreateBodyPrefab(GameObject newBodyPrefab, AssetBundle assetBundle, string modelName, BodyInfo bodyInfo)
+        public static GameObject CreateBodyPrefab(ContentPackContainer contentPack, GameObject newBodyPrefab, AssetBundle assetBundle, string modelName, BodyInfo bodyInfo)
         {
-            return CreateBodyPrefab(newBodyPrefab, LoadCharacterModel(assetBundle, modelName), bodyInfo);
+            return CreateBodyPrefab(contentPack, newBodyPrefab, LoadCharacterModel(assetBundle, modelName), bodyInfo);
         }
         /// <summary>
         /// loads your body from the assetbundle, loads your model from the assetbundle, and set up components on both objects through code
         /// </summary>
-        public static GameObject CreateBodyPrefab(AssetBundle assetBundle, string bodyPrefabName, string modelPrefabName, BodyInfo bodyInfo)
+        public static GameObject CreateBodyPrefab(ContentPackContainer contentPack, AssetBundle assetBundle, string bodyPrefabName, string modelPrefabName, BodyInfo bodyInfo)
         {
-            return CreateBodyPrefab(LoadCharacterBody(assetBundle, bodyPrefabName), LoadCharacterModel(assetBundle, modelPrefabName), bodyInfo);
+            return CreateBodyPrefab(contentPack, LoadCharacterBody(assetBundle, bodyPrefabName), LoadCharacterModel(assetBundle, modelPrefabName), bodyInfo);
         }
         /// <summary>
         /// Pass in a body prefab, pass in a model prefab, and set up components on both objects through code
         /// </summary>
-        public static GameObject CreateBodyPrefab(GameObject newBodyPrefab, GameObject model, BodyInfo bodyInfo)
+        public static GameObject CreateBodyPrefab(ContentPackContainer contentPack, GameObject newBodyPrefab, GameObject model, BodyInfo bodyInfo)
         {
             if (model == null || newBodyPrefab == null)
             {
@@ -132,7 +132,7 @@ namespace HenryAPI.Modules
             //SetupRigidbody(newPrefab);
             SetupCapsuleCollider(newBodyPrefab);
 
-            Modules.Content.AddCharacterBodyPrefab(newBodyPrefab);
+            Modules.Content.AddCharacterBodyPrefab(contentPack, newBodyPrefab);
 
             return newBodyPrefab;
         }
@@ -545,21 +545,21 @@ namespace HenryAPI.Modules
         #endregion
 
         #region master
-        public static void CreateGenericDoppelganger(GameObject bodyPrefab, string masterName, string masterToCopy) => CloneDopplegangerMaster(bodyPrefab, masterName, masterToCopy);
-        public static GameObject CloneDopplegangerMaster(GameObject bodyPrefab, string masterName, string masterToCopy)
+        public static void CreateGenericDoppelganger(ContentPackContainer contentPack,GameObject bodyPrefab, string masterName, string masterToCopy) => CloneDopplegangerMaster(contentPack,bodyPrefab, masterName, masterToCopy);
+        public static GameObject CloneDopplegangerMaster(ContentPackContainer contentPack, GameObject bodyPrefab, string masterName, string masterToCopy)
         {
             GameObject newMaster = PrefabAPI.InstantiateClone(RoR2.LegacyResourcesAPI.Load<GameObject>("Prefabs/CharacterMasters/" + masterToCopy + "MonsterMaster"), masterName, true);
             newMaster.GetComponent<CharacterMaster>().bodyPrefab = bodyPrefab;
 
-            Modules.Content.AddMasterPrefab(newMaster);
+            Modules.Content.AddMasterPrefab(contentPack, newMaster);
             return newMaster;
         }
 
-        public static GameObject CreateBlankMasterPrefab(GameObject bodyPrefab, string masterName)
+        public static GameObject CreateBlankMasterPrefab(ContentPackContainer contentPack, GameObject bodyPrefab, string masterName)
         {
             GameObject masterObject = PrefabAPI.InstantiateClone(RoR2.LegacyResourcesAPI.Load<GameObject>("Prefabs/CharacterMasters/CommandoMonsterMaster"), masterName, true);
             //should the user call this themselves?
-            Modules.ContentPacks.masterPrefabs.Add(masterObject);
+            contentPack.masterPrefabs.Add(masterObject);
 
             CharacterMaster characterMaster = masterObject.GetComponent<CharacterMaster>();
             characterMaster.bodyPrefab = bodyPrefab;
@@ -573,7 +573,7 @@ namespace HenryAPI.Modules
             return masterObject;
         }
 
-        public static GameObject LoadMaster(this AssetBundle assetBundle, GameObject bodyPrefab, string assetName)
+        public static GameObject LoadMaster(this AssetBundle assetBundle, ContentPackContainer contentPack, GameObject bodyPrefab, string assetName)
         {
             GameObject newMaster = assetBundle.LoadAsset<GameObject>(assetName);
 
@@ -602,7 +602,7 @@ namespace HenryAPI.Modules
             characterMaster.bodyPrefab = bodyPrefab;
             characterMaster.teamIndex = TeamIndex.Monster;
 
-            Modules.Content.AddMasterPrefab(newMaster);
+            Modules.Content.AddMasterPrefab(contentPack,newMaster);
             return newMaster;
         }
         #endregion master

--- a/HenryMod/Modules/Prefabs.cs
+++ b/HenryMod/Modules/Prefabs.cs
@@ -9,7 +9,7 @@ using RoR2.Skills;
 using System;
 using System.Linq;
 
-namespace HenryMod.Modules
+namespace HenryAPI.Modules
 {
     // module for creating body prefabs and whatnot
     // recommended to simply avoid touching this unless you REALLY need to

--- a/HenryMod/Modules/Skills.cs
+++ b/HenryMod/Modules/Skills.cs
@@ -3,7 +3,7 @@ using RoR2;
 using RoR2.Skills;
 using System;
 using System.Collections.Generic;
-using HenryMod;
+using HenryAPI;
 using UnityEngine;
 
 namespace HenryAPI.Modules
@@ -26,16 +26,16 @@ namespace HenryAPI.Modules
                 switch (slots[i])
                 {
                     case SkillSlot.Primary:
-                        skillLocator.primary = CreateGenericSkillWithSkillFamily(targetPrefab, "Primary");
+                        skillLocator.primary = CreateGenericSkillWithSkillFamily(targetPrefab, SkillSlot.Primary);
                         break;
                     case SkillSlot.Secondary:
-                        skillLocator.secondary = CreateGenericSkillWithSkillFamily(targetPrefab, "Secondary");
+                        skillLocator.secondary = CreateGenericSkillWithSkillFamily(targetPrefab, SkillSlot.Secondary);
                         break;
                     case SkillSlot.Utility:
-                        skillLocator.utility = CreateGenericSkillWithSkillFamily(targetPrefab, "Utility");
+                        skillLocator.utility = CreateGenericSkillWithSkillFamily(targetPrefab, SkillSlot.Utility);
                         break;
                     case SkillSlot.Special:
-                        skillLocator.special = CreateGenericSkillWithSkillFamily(targetPrefab, "Special");
+                        skillLocator.special = CreateGenericSkillWithSkillFamily(targetPrefab, SkillSlot.Special);
                         break;
                     case SkillSlot.None:
                         break;
@@ -57,21 +57,21 @@ namespace HenryAPI.Modules
             switch (skillSlot)
             {
                 case SkillSlot.Primary:
-                    return skillLocator.primary = CreateGenericSkillWithSkillFamily(targetPrefab, "Primary", hidden);
+                    return skillLocator.primary = CreateGenericSkillWithSkillFamily(targetPrefab, SkillSlot.Primary, hidden);
                 case SkillSlot.Secondary:
-                    return skillLocator.secondary = CreateGenericSkillWithSkillFamily(targetPrefab, "Secondary", hidden);
+                    return skillLocator.secondary = CreateGenericSkillWithSkillFamily(targetPrefab, SkillSlot.Secondary, hidden);
                 case SkillSlot.Utility:
-                    return skillLocator.utility = CreateGenericSkillWithSkillFamily(targetPrefab, "Utility", hidden);
+                    return skillLocator.utility = CreateGenericSkillWithSkillFamily(targetPrefab, SkillSlot.Utility, hidden);
                 case SkillSlot.Special:
-                    return skillLocator.special = CreateGenericSkillWithSkillFamily(targetPrefab, "Special", hidden);
+                    return skillLocator.special = CreateGenericSkillWithSkillFamily(targetPrefab, SkillSlot.Special, hidden);
                 case SkillSlot.None:
                     Log.Error("Failed to create GenericSkill with skillslot None. If making a GenericSkill outside of the main 4, specify a familyName, and optionally a genericSkillName");
                     return null;
             }
             return null;
         }
-        public static GenericSkill CreateGenericSkillWithSkillFamily(GameObject targetPrefab, string familyName, bool hidden = false) => CreateGenericSkillWithSkillFamily(targetPrefab, familyName, familyName, hidden);
-        public static GenericSkill CreateGenericSkillWithSkillFamily(GameObject targetPrefab, string genericSkillName, string familyName, bool hidden = false)
+        public static GenericSkill CreateGenericSkillWithSkillFamily(ContentPackContainer contentPack, GameObject targetPrefab, string familyName, bool hidden = false) => CreateGenericSkillWithSkillFamily(contentPack, targetPrefab, familyName, familyName, hidden);
+        public static GenericSkill CreateGenericSkillWithSkillFamily(ContentPackContainer contentPack, GameObject targetPrefab, string genericSkillName, string familyName, bool hidden = false)
         {
             GenericSkill skill = targetPrefab.AddComponent<GenericSkill>();
             skill.skillName = genericSkillName;
@@ -83,7 +83,7 @@ namespace HenryAPI.Modules
 
             skill._skillFamily = newFamily;
 
-            Content.AddSkillFamily(newFamily);
+            Content.AddSkillFamily(contentPack, newFamily);
             return skill;
         }
         #endregion

--- a/HenryMod/Modules/Skills.cs
+++ b/HenryMod/Modules/Skills.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using HenryMod;
 using UnityEngine;
 
-namespace HenryMod.Modules
+namespace HenryAPI.Modules
 {
     internal static class Skills
     {

--- a/HenryMod/Modules/Skins.cs
+++ b/HenryMod/Modules/Skins.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace HenryMod.Modules
+namespace HenryAPI.Modules
 {
     internal static class Skins
     {

--- a/HenryMod/Modules/Tokens.cs
+++ b/HenryMod/Modules/Tokens.cs
@@ -1,4 +1,4 @@
-﻿namespace HenryMod.Modules
+﻿namespace HenryAPI.Modules
 {
     internal static class Tokens
     {

--- a/Readme.md
+++ b/Readme.md
@@ -1,2 +1,1 @@
-# Henry Tutorial
-Head to the [Wiki](https://github.com/ArcPh1r3/HenryTutorial/wiki) tab to get started.
+# HenryAPI


### PR DESCRIPTION
This PR
- Renames some namespaces and parts of the project to HenryAPI
- Gets rid of Content Pack as a static class and instead is a class a user can create, and  pass by reference to the various functions in the codebase

TODO:
- Rather then forcing users to use our implementation of content pack class, we can make it an interface and consumers of the API can make their own implementations or just use our default one